### PR TITLE
Fixing AddUrlRequest for base32 encoded magnet links.

### DIFF
--- a/UTorrentClientApi/File/TorrentInfo.cs
+++ b/UTorrentClientApi/File/TorrentInfo.cs
@@ -304,8 +304,11 @@ namespace UTorrent.Api.File
                     value = s.Substring(si, i - si);
                 }
 
-                // add name / value pair to the collection
-                result.Add(name, value);
+                if (result.ContainsKey(name))
+                {
+                    // add name / value pair to the collection
+                    result.Add(name, value);
+                }
 
                 // trailing '&'
 

--- a/UTorrentClientApi/Tools/Base32Helper.cs
+++ b/UTorrentClientApi/Tools/Base32Helper.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+namespace UTorrent.Api.Tools
+{
+    public sealed class Base32Helper
+    {
+        public static byte[] ToBytes(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                throw new ArgumentNullException(nameof(input));
+
+            input = input.TrimEnd('='); //remove padding characters
+            var byteCount = input.Length*5/8; //this must be TRUNCATED
+            var returnArray = new byte[byteCount];
+
+            byte curByte = 0, bitsRemaining = 8;
+            var arrayIndex = 0;
+
+            foreach (var c in input)
+            {
+                var cValue = CharToValue(c);
+
+                var mask = 0;
+                if (bitsRemaining > 5)
+                {
+                    mask = cValue << (bitsRemaining - 5);
+                    curByte = (byte) (curByte | mask);
+                    bitsRemaining -= 5;
+                }
+                else
+                {
+                    mask = cValue >> (5 - bitsRemaining);
+                    curByte = (byte) (curByte | mask);
+                    returnArray[arrayIndex++] = curByte;
+                    curByte = (byte) (cValue << (3 + bitsRemaining));
+                    bitsRemaining += 3;
+                }
+            }
+
+            //if we didn't end with a full byte
+            if (arrayIndex != byteCount)
+                returnArray[arrayIndex] = curByte;
+
+            return returnArray;
+        }
+
+        private static int CharToValue(char c)
+        {
+            int value = c;
+
+            //65-90 == uppercase letters
+            if ((value < 91) && (value > 64))
+                return value - 65;
+            //50-55 == numbers 2-7
+            if ((value < 56) && (value > 49))
+                return value - 24;
+            //97-122 == lowercase letters
+            if ((value < 123) && (value > 96))
+                return value - 97;
+
+            throw new ArgumentException("Character is not a Base32 character.", nameof(c));
+        }
+    }
+}

--- a/UTorrentClientApi/Tools/Base32Helper.cs
+++ b/UTorrentClientApi/Tools/Base32Helper.cs
@@ -4,6 +4,7 @@ namespace UTorrent.Api.Tools
 {
     public sealed class Base32Helper
     {
+        // http://stackoverflow.com/a/7135008
         public static byte[] ToBytes(string input)
         {
             if (string.IsNullOrEmpty(input))


### PR DESCRIPTION
Wikipidia
https://en.wikipedia.org/wiki/Magnet_URI_scheme

> BTIH
>  (BitTorrent Info Hash)
> These are hex encoded SHA-1 hash sums of the "info" sections of BitTorrent metafiles as used by BitTorrent to identify downloadable files or sets of files. For backwards compatibility with existing links, clients should also support the Base32 encoded version of the hash.[1]
