### PR TITLE
Bugfix in dotnetcore

### DIFF
--- a/UTorrentClientApi/Requests/BaseRequest.cs
+++ b/UTorrentClientApi/Requests/BaseRequest.cs
@@ -253,11 +253,11 @@ namespace UTorrent.Api
 
 #if !PORTABLE
             using (var response = wr.GetResponse())
-            using (var stream = response.GetResponseStream())
 #else
-            using(var stream = wr.GetRequestStreamAsync().Result)
+            using (var response = wr.GetResponseAsync().Result)
 #endif
-            {
+            using (var stream = response.GetResponseStream())
+            { 
                 if (stream == null)
                     throw new InvalidOperationException("Response stream is null");
 


### PR DESCRIPTION
Fixed an issue where the following exception was thrown when using this in a dotnetcore project.

System.AggregateException: One or more errors occurred. (Cannot send a content-body with this verb-type.)

Stack trace:
```
System.AggregateException: One or more errors occurred. (Cannot send a content-body with this verb-type.) ---> System.Net.ProtocolViolationException: Cannot send a content-body with this verb-type.
   at System.Net.HttpWebRequest.GetRequestStream()
   at System.Net.HttpWebRequest.BeginGetRequestStream(AsyncCallback callback, Object state)
   at System.Net.WebRequest.<>c.<GetRequestStreamAsync>b__36_1(AsyncCallback callback, Object state)
   at System.Threading.Tasks.TaskFactory`1.FromAsyncImpl(Func`3 beginMethod, Func`2 endFunction, Action`1 endAction, Object state, TaskCreationOptions creationOptions)
   at System.Threading.Tasks.TaskFactory`1.FromAsync(Func`3 beginMethod, Func`2 endMethod, Object state)
   at System.Net.WebRequest.<GetRequestStreamAsync>b__36_0()
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.Tasks.Task.Execute()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at UTorrent.Api.BaseRequest`1.ProcessRequest(String token, String logOn, String password, Cookie cookie) in C:\PROJECTS\PRIVATE\github\UTorrentClientApi\UTorrentClientApi\Requests\BaseRequest.cs:line 258
   at UTorrent.Api.UTorrentClient.ProcessRequest[TResponse](BaseRequest`1 request) in C:\PROJECTS\PRIVATE\github\UTorrentClientApi\UTorrentClientApi\UTorrentClient.cs:line 837
   at UTorrent.Api.UTorrentClient.GetList(Int32 cacheId) in C:\PROJECTS\PRIVATE\github\UTorrentClientApi\UTorrentClientApi\UTorrentClient.cs:line 155
   at UTorrent.Api.UTorrentClient.GetList() in C:\PROJECTS\PRIVATE\github\UTorrentClientApi\UTorrentClientApi\UTorrentClient.cs:line 130
```